### PR TITLE
Provide helm distro to test from test suite

### DIFF
--- a/common-envvars.sh
+++ b/common-envvars.sh
@@ -1,2 +1,3 @@
 OPERATOR_NAMESPACE=keylime
 OPERATOR_NAME=attestation-operator
+HELM_IMAGE_VERSION=oci://quay.io/sec-eng-special/openshift-attestation-operator-helm/keylime


### PR DESCRIPTION
Before, the helm distribution to install was hardcoded inside the common-cloud-orchestration repository. After it being fixed, now `HELM_IMAGE_VERSION` must be configured for the test suite to work appropriately. More information: https://github.com/RedHat-SP-Security/common-cloud-orchestration/pull/13

Resolves: #20 